### PR TITLE
rtl838x: fix sysupgrade for Zyxel GS1900-10HP

### DIFF
--- a/target/linux/rtl838x/dts/rtl8380_zyxel_gs1900-10hp.dts
+++ b/target/linux/rtl838x/dts/rtl8380_zyxel_gs1900-10hp.dts
@@ -6,7 +6,7 @@
 #include <dt-bindings/gpio/gpio.h>
 
 / {
-	compatible = "zyxel,gs1900", "realtek,rtl838x-soc";
+	compatible = "zyxel,gs1900-10hp", "realtek,rtl838x-soc";
 	model = "Zyxel GS1900-10HP Switch";
 
 	aliases {
@@ -80,7 +80,7 @@
 				reg = <0x160000 0x100000>;
 			};
 			partition@b260000 {
-				label = "runtime";
+				label = "firmware";
 				reg = <0x260000 0x6d0000>;
 				compatible = "denx,uimage";
 			};


### PR DESCRIPTION
Sysupgrade wants a partition called 'firmware' and needs
the otherwise unused compatible string to match.

Signed-off-by: Andreas Oberritter <obi@saftware.de>