### PR TITLE
Rtl83xx vlan clean

### DIFF
--- a/target/linux/rtl838x/files-5.4/drivers/net/dsa/rtl838x.h
+++ b/target/linux/rtl838x/files-5.4/drivers/net/dsa/rtl838x.h
@@ -68,11 +68,13 @@
 #define RTL838X_VLAN_PORT_EGR_FLTR		(0x3A84)
 #define RTL838X_VLAN_PORT_PB_VLAN(port)		(0x3C00 + ((port) << 2))
 #define RTL838X_VLAN_PORT_IGR_FLTR(port)	(0x3A7C + (((port >> 4) << 2)))
+#define RTL838X_VLAN_PORT_TAG_STS_CTRL(port)	(0xA530 + (((port) << 2)))
 #define RTL839X_VLAN_PROFILE(idx)		(0x25C0 + (((idx) << 3)))
 #define RTL839X_VLAN_CTRL			(0x26D4)
 #define RTL839X_VLAN_PORT_PB_VLAN(port)		(0x26D8 + (((port) << 2)))
 #define RTL839X_VLAN_PORT_IGR_FLTR(port)	(0x27B4 + (((port >> 4) << 2)))
 #define RTL839X_VLAN_PORT_EGR_FLTR(port)	(0x27C4 + (((port >> 5) << 2)))
+#define RTL839X_VLAN_PORT_TAG_STS_CTRL(port)	(0x6828 + (((port) << 2)))
 
 /* Table 0/1 access registers */
 #define RTL838X_TBL_ACCESS_CTRL_0		(0x6914)
@@ -352,6 +354,7 @@ struct rtl838x_reg {
 	int (*vlan_port_egr_filter)(int port);
 	int (*vlan_port_igr_filter)(int port);
 	int (*vlan_port_pb)(int port);
+	int (*vlan_port_tag_sts_ctrl)(int port);
 	int (*trk_mbr_ctr)(int group);
 	int rma_bpdu_fld_pmask;
 	int spcl_trap_eapol_ctrl;

--- a/target/linux/rtl838x/files-5.4/drivers/net/dsa/rtl838x_debugfs.c
+++ b/target/linux/rtl838x/files-5.4/drivers/net/dsa/rtl838x_debugfs.c
@@ -224,6 +224,9 @@ static int rtl838x_dbgfs_port_init(struct dentry *parent, struct rtl838x_switch_
 
 		debugfs_create_x32("storm_rate_bc", 0644, port_dir,
 				(u32 *)(RTL838X_SW_BASE + RTL838X_STORM_CTRL_PORT_BC(port)));
+
+		debugfs_create_x32("vlan_port_tag_sts_ctrl", 0644, port_dir,
+				(u32 *)(RTL838X_SW_BASE + RTL838X_VLAN_PORT_TAG_STS_CTRL(port)));
 	} else {
 		debugfs_create_x32("storm_rate_uc", 0644, port_dir,
 				(u32 *)(RTL838X_SW_BASE + RTL839X_STORM_CTRL_PORT_UC_0(port)));
@@ -233,6 +236,9 @@ static int rtl838x_dbgfs_port_init(struct dentry *parent, struct rtl838x_switch_
 
 		debugfs_create_x32("storm_rate_bc", 0644, port_dir,
 				(u32 *)(RTL838X_SW_BASE + RTL839X_STORM_CTRL_PORT_BC_0(port)));
+
+		debugfs_create_x32("vlan_port_tag_sts_ctrl", 0644, port_dir,
+				(u32 *)(RTL838X_SW_BASE + RTL839X_VLAN_PORT_TAG_STS_CTRL(port)));
 	}
 
 	debugfs_create_u32("id", 0444, port_dir, (u32 *)&priv->ports[port].dp->index);

--- a/target/linux/rtl838x/files-5.4/drivers/net/dsa/rtl838x_sw.c
+++ b/target/linux/rtl838x/files-5.4/drivers/net/dsa/rtl838x_sw.c
@@ -2092,7 +2092,10 @@ static int rtl838x_vlan_del(struct dsa_switch *ds, int port,
 
 		/* remove port from both tables */
 		info.untagged_ports &= (~BIT_ULL(port));
-		info.tagged_ports &= (~BIT_ULL(port));
+
+		/* always leave vid 1 */
+		if (v != 1)
+			info.tagged_ports &= (~BIT_ULL(port));
 
 		priv->r->vlan_set_untagged(v, info.untagged_ports);
 		pr_info("Untagged ports, VLAN %d: %llx\n", v, info.untagged_ports);

--- a/target/linux/rtl838x/files-5.4/drivers/net/dsa/rtl838x_sw.c
+++ b/target/linux/rtl838x/files-5.4/drivers/net/dsa/rtl838x_sw.c
@@ -1278,6 +1278,8 @@ static int rtl838x_setup(struct dsa_switch *ds)
 
 	rtl838x_init_stats(priv);
 
+	ds->configure_vlan_while_not_filtering = true;
+
 	/* Enable MAC Polling PHY again */
 	rtl838x_enable_phy_polling(priv);
 	pr_info("Please wait until PHY is settled\n");

--- a/target/linux/rtl838x/files-5.4/drivers/net/dsa/rtl838x_sw.c
+++ b/target/linux/rtl838x/files-5.4/drivers/net/dsa/rtl838x_sw.c
@@ -193,6 +193,16 @@ inline int rtl839x_vlan_port_pb(int port)
 	return RTL839X_VLAN_PORT_PB_VLAN(port);
 }
 
+inline int rtl838x_vlan_port_tag_sts_ctrl(int port)
+{
+	return RTL838X_VLAN_PORT_TAG_STS_CTRL(port);
+}
+
+inline int rtl839x_vlan_port_tag_sts_ctrl(int port)
+{
+	return RTL839X_VLAN_PORT_TAG_STS_CTRL(port);
+}
+
 inline static int rtl838x_trk_mbr_ctr(int group)
 {
 	return RTL838X_TRK_MBR_CTR + (group << 2);
@@ -635,6 +645,7 @@ static const struct rtl838x_reg rtl838x_reg = {
 	.vlan_port_egr_filter = rtl838x_vlan_port_egr_filter,
 	.vlan_port_igr_filter = rtl838x_vlan_port_igr_filter,
 	.vlan_port_pb = rtl838x_vlan_port_pb,
+	.vlan_port_tag_sts_ctrl = rtl838x_vlan_port_tag_sts_ctrl,
 	.trk_mbr_ctr = rtl838x_trk_mbr_ctr,
 	.rma_bpdu_fld_pmask = RTL838X_RMA_BPDU_FLD_PMSK,
 	.spcl_trap_eapol_ctrl = RTL838X_SPCL_TRAP_EAPOL_CTRL,
@@ -684,6 +695,7 @@ static const struct rtl838x_reg rtl839x_reg = {
 	.vlan_port_egr_filter = rtl839x_vlan_port_egr_filter,
 	.vlan_port_igr_filter = rtl839x_vlan_port_igr_filter,
 	.vlan_port_pb = rtl839x_vlan_port_pb,
+	.vlan_port_tag_sts_ctrl = rtl839x_vlan_port_tag_sts_ctrl,
 	.trk_mbr_ctr = rtl839x_trk_mbr_ctr,
 	.rma_bpdu_fld_pmask = RTL839X_RMA_BPDU_FLD_PMSK,
 	.spcl_trap_eapol_ctrl = RTL839X_SPCL_TRAP_EAPOL_CTRL,
@@ -2190,6 +2202,9 @@ static int rtl838x_port_enable(struct dsa_switch *ds, int port,
 
 	pr_info("%s: %x %d", __func__, (u32) priv, port);
 	priv->ports[port].enable = true;
+
+	/* enable inner tagging on egress, do not keep any tags */
+	sw_w32(1, priv->r->vlan_port_tag_sts_ctrl(port));
 
 	if (dsa_is_cpu_port(ds, port))
 		return 0;


### PR DESCRIPTION
This fixes forwarding between untagged and tagged ports.  I have also included a simple workaround for the observed VLAN 1 magic.  Feel free to drop that if you think it's inappropriate.

There is still one minor annoyance left:  The first packet received on a port+vlan is duplicated.  I assume that's related to how we handle flooding.