### PR TITLE
realtek: add support for Zyxel XGS1010-12

### DIFF
--- a/target/linux/realtek/dts-5.10/rtl9302_zyxel_xgs1010-12.dts
+++ b/target/linux/realtek/dts-5.10/rtl9302_zyxel_xgs1010-12.dts
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: (GPL-2.0-or-later or MIT)
+/dts-v1/;
+
+#include "rtl9302_zyxel_xgs1210-12.dts"
+
+/ {
+	compatible = "zyxel,xgs1010-12", "realtek,rtl838x-soc";
+	model = "Zyxel XGS1010-12 Switch";
+};
+
+&partitions {
+	compatible = "fixed-partitions";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	partition@300000 {
+		label = "firmware";
+		reg = <0x300000 0x680000>;
+		compatible = "openwrt,uimage", "denx,uimage";
+		openwrt,ih-magic = <0x93001010>;
+	};
+	/delete-node/ partition@fe0000;
+	partition@980000 {
+		label = "firmware2";
+		reg = <0x980000 0x680000>;
+	};
+};

--- a/target/linux/realtek/image/rtl930x.mk
+++ b/target/linux/realtek/image/rtl930x.mk
@@ -1,5 +1,17 @@
 # SPDX-License-Identifier: GPL-2.0-only
 
+define Device/zyxel_xgs1010-12
+	SOC := rtl9302
+	UIMAGE_MAGIC := 0x93001010
+	ZYXEL_VERS := ABTY
+	DEVICE_VENDOR := Zyxel
+	DEVICE_MODEL := XGS1010-12
+	IMAGE_SIZE := 13312k
+	KERNEL_INITRAMFS := kernel-bin | append-dtb | gzip | zyxel-vers $$$$(ZYXEL_VERS) | \
+	                    uImage gzip
+endef
+TARGET_DEVICES += zyxel_xgs1010-12
+
 define Device/zyxel_xgs1210-12
   SOC := rtl9302
   UIMAGE_MAGIC := 0x93001210


### PR DESCRIPTION
The Zyxel XGS1010-12 is an 8x 1 GBit, 2x 2.5 GBit NBaseT ports and
2 SFP+ ports switch. It is identical to the Zyxel XGS1210-12, except for
the partition layout which is probably caused by the basic firmware
coming from the SDK with the default dual partition layout. To ensure
backwards compatibility, it is best to keep the original partition
layout.
    
If a larger, single firmware partition, is desired, one can still
install the XGS1210-12 firmware onto the switch.
    
In addition to the above, the XGS1010-12 lacks a physical reset button,
but all circuitry is in place to support this, including the whole in
the metal housing. As such, we keep the dts entry for the button, to
allow the user to solder on a button, or short the pins, if they so
desire.
    
As this switch does not feature any form of management or firmware
updateability, one must use the serial UART either through XYZ-modem
((untested) or tftp. The instructions to do so are identical as with the
XGS1250-12.